### PR TITLE
Feature/Disable snapshots on GitHub Packages

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,15 @@
             <layout>default</layout>
             <name>GitHub zetool Apache Maven Packages</name>
             <url>https://maven.pkg.github.com/zetool/common</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </distributionManagement>
 
     <scm>
         <connection>scm:git:https://github.com/zetool/common.git</connection>
         <url>https://github.com/zetool/common.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 </project>


### PR DESCRIPTION
Update repository definition such that maven deploy to GitHub packages is not executed for snapshot releases.